### PR TITLE
replace references to jonabc org with github org

### DIFF
--- a/.github/workflows/licensed-ci.yaml
+++ b/.github/workflows/licensed-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     # run licensed-ci to check and update licenses
-    - uses: jonabc/licensed-ci@v1
+    - uses: github/licensed-ci@v1
       with:
         workflow: push_for_bots
         dependabot_skip: 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contributing
 
-[fork]: https://github.com/jonabc/setup-licensed/fork
-[pr]: https://github.com/jonabc/setup-licensed/compare
-[style]: https://github.com/jonabc/setup-licensed/blob/main/.eslintrc.json
+[fork]: https://github.com/github/setup-licensed/fork
+[pr]: https://github.com/github/setup-licensed/compare
+[style]: https://github.com/github/setup-licensed/blob/main/.eslintrc.json
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ steps:
 - uses: actions/setup-node@v3
 - run: npm install # install dependencies in local environment
 
-# setup ruby environment before running jonabc/setup-licensed
+# setup ruby environment before running github/setup-licensed
 - uses: ruby/setup-ruby@v1
   with:
     ruby-version: ruby
 
-- uses: jonabc/setup-licensed@v1
+- uses: github/setup-licensed@v1
   with:
     version: '4.x' # required: supports matching based on string equivalence or node-semver range
     install-dir: /path/to/install/at # optional: defaults to /usr/local/bin

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jonabc/setup-licensed.git"
+    "url": "git+https://github.com/github/setup-licensed.git"
   },
   "keywords": [
     "GitHub",
@@ -20,9 +20,9 @@
   "author": "Jon Ruskin",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jonabc/setup-licensed/issues"
+    "url": "https://github.com/github/setup-licensed/issues"
   },
-  "homepage": "https://github.com/jonabc/setup-licensed#readme",
+  "homepage": "https://github.com/github/setup-licensed#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",


### PR DESCRIPTION
### Description

With the transfer of this repository from `jonabc` org to `github` org, the URLs referencing the action and the statements using the action needed to be updated.  This PR updates those org references.